### PR TITLE
Add .dts files for raspi-display with qsxp-ml81 on qsbase4

### DIFF
--- a/conf/machine/qsxp-ml81.conf
+++ b/conf/machine/qsxp-ml81.conf
@@ -46,5 +46,6 @@ KERNEL_DEVICETREE ?= "\
         freescale/imx8mp-qsxp-ml81-qsbase4-dsi83.dtb \
         freescale/imx8mp-qsxp-ml81-qsbase3-laird.dtb \
         freescale/imx8mp-qsxp-ml81-qsbase3-raspi-display.dtb \
+        freescale/imx8mp-qsxp-ml81-qsbase4-raspi-display.dtb \
         freescale/imx8mp-qsxp-ml81-qsbase3-tc358867.dtb \
 "

--- a/recipes-kernel/linux/linux-karo-5.15/mx8-nxp-bsp/dts/freescale/imx8mp-qsxp-ml81-qsbase4-raspi-display.dts
+++ b/recipes-kernel/linux/linux-karo-5.15/mx8-nxp-bsp/dts/freescale/imx8mp-qsxp-ml81-qsbase4-raspi-display.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2022 Felix Klöckner <f.kloeckner@weinmann-emt.de>
+ *
+ */
+
+#include "imx8mp-qsxp-ml81-qsbase3-raspi-display.dts"
+
+/ {
+	model = "Ka-Ro electronics QSXP-ML81 (NXP i.MX8MP) module on QSBASE4 baseboard with Raspi Display";
+};
+
+&eqos {
+	phy-mode = "rgmii-id";
+	phy-handle = <&ethphy1>;
+
+	mdio {
+		ethphy1: ethernet-phy@7 {
+			reg = <7>;
+		};
+	};
+};
+
+&ethphy0 {
+	status = "disabled";
+};
+
+&usb_dwc3_1 {
+	/delete-property/ vbus-supply;
+};
+
+&pinctrl_eqos {
+	fsl,pins = <
+		    MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC				0x142
+		    MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO			0x142
+		    MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK 	0x40000016
+		    MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0			0x016
+		    MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1			0x016
+		    MX8MP_IOMUXC_ENET_TD2__ENET_QOS_RGMII_TD2			0x016
+		    MX8MP_IOMUXC_ENET_TD3__ENET_QOS_RGMII_TD3			0x016
+		    MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL 		0x016
+		    MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0			0x110 /* MODE0 */
+		    MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1			0x150 /* MODE1 */
+		    MX8MP_IOMUXC_ENET_RD2__ENET_QOS_RGMII_RD2			0x150 /* MODE2 */
+		    MX8MP_IOMUXC_ENET_RD3__ENET_QOS_RGMII_RD3			0x150 /* MODE3 */
+		    MX8MP_IOMUXC_ENET_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK 	0x156 /* PHYAD2 */
+		    MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL 		0x000 /* CLK125_EN */
+		    MX8MP_IOMUXC_GPIO1_IO00__CCM_ENET_PHY_REF_CLK_ROOT		0x110 /* LED_MODE */
+	>;
+};

--- a/recipes-kernel/linux/linux-karo_5.15.bb
+++ b/recipes-kernel/linux/linux-karo_5.15.bb
@@ -69,6 +69,7 @@ SRC_URI:append:mx8-nxp-bsp = " \
 	file://dts/freescale/imx8mp-qsxp-ml81-qsbase3-laird.dts;subdir=git/${KERNEL_OUTPUT_DIR} \
 	file://dts/freescale/imx8mp-qsxp-ml81-qsbase3-laird.dtsi;subdir=git/${KERNEL_OUTPUT_DIR} \
 	file://dts/freescale/imx8mp-qsxp-ml81-qsbase3-raspi-display.dts;subdir=git/${KERNEL_OUTPUT_DIR} \
+	file://dts/freescale/imx8mp-qsxp-ml81-qsbase4-raspi-display.dts;subdir=git/${KERNEL_OUTPUT_DIR} \
 	file://dts/freescale/imx8mp-qsxp-ml81-qsbase3-raspi-display.dtsi;subdir=git/${KERNEL_OUTPUT_DIR} \
 	file://dts/freescale/imx8mp-qsxp-ml81-qsbase3-tc358867.dts;subdir=git/${KERNEL_OUTPUT_DIR} \
 	file://dts/freescale/imx8mp-qsxp-ml81-qsbase3.dts;subdir=git/${KERNEL_OUTPUT_DIR} \


### PR DESCRIPTION
Hello,
I recently bought a QSBASE4 evalkit with a QSXP Module. Together with a Raspberry Pi touch display.
To attach the display I created a new devicetree based on the one used for the QBASE3 evalkit. Ethernet and USB is working too.
I think it will be of value for other users as well so I would be happy if you would integrate it into the karo repo.

Regards
Felix Klöckner